### PR TITLE
Fix javadoc errors

### DIFF
--- a/core/roboconf-core/src/main/java/net/roboconf/core/dsl/ParsingModelIo.java
+++ b/core/roboconf-core/src/main/java/net/roboconf/core/dsl/ParsingModelIo.java
@@ -54,7 +54,7 @@ public final class ParsingModelIo {
 	 * @param ignoreComments true to ignore comments during parsing
 	 * @return an instance of {@link FileDefinition} (never null)
 	 * <p>
-	 * Parsing errors are stored in the result.<br />
+	 * Parsing errors are stored in the result.<br>
 	 * See {@link FileDefinition#getParsingErrors()}.
 	 * </p>
 	 */

--- a/core/roboconf-core/src/main/java/net/roboconf/core/dsl/converters/FromGraphDefinition.java
+++ b/core/roboconf-core/src/main/java/net/roboconf/core/dsl/converters/FromGraphDefinition.java
@@ -100,7 +100,7 @@ public class FromGraphDefinition {
 	 * @param file the initial file to parse
 	 * @return a graph(s)
 	 * <p>
-	 * The result is not significant if there are errors.<br />
+	 * The result is not significant if there are errors.<br>
 	 * Conversion errors are available by using {@link #getErrors()}.
 	 * </p>
 	 */

--- a/core/roboconf-core/src/main/java/net/roboconf/core/dsl/converters/FromInstanceDefinition.java
+++ b/core/roboconf-core/src/main/java/net/roboconf/core/dsl/converters/FromInstanceDefinition.java
@@ -103,7 +103,7 @@ public class FromInstanceDefinition {
 	 * @param file the file to parse
 	 * @return a non-null collection of root rootInstances wrapped in machines
 	 * <p>
-	 * The result is not significant if there are errors.<br />
+	 * The result is not significant if there are errors.<br>
 	 * Conversion errors are available by using {@link #getErrors()}.
 	 * </p>
 	 */

--- a/core/roboconf-core/src/main/java/net/roboconf/core/internal/dsl/parsing/FileDefinitionParser.java
+++ b/core/roboconf-core/src/main/java/net/roboconf/core/internal/dsl/parsing/FileDefinitionParser.java
@@ -90,7 +90,7 @@ public class FileDefinitionParser {
 	 * Reads a definition file.
 	 * @return an instance of {@link FileDefinition} (never null)
 	 * <p>
-	 * Parsing errors are stored in the result.<br />
+	 * Parsing errors are stored in the result.<br>
 	 * See {@link FileDefinition#getParsingErrors()}.
 	 * </p>
 	 */
@@ -302,7 +302,7 @@ public class FileDefinitionParser {
 	 * @param line a string (not null)
 	 * @return an array of 2 strings
 	 * <p>
-	 * Index 0: the line without the in-line comment. Never null.<br />
+	 * Index 0: the line without the in-line comment. Never null.<br>
 	 * Index 1: the in-line comment (if not null, it starts with a '#' symbol).
 	 * </p>
 	 */

--- a/core/roboconf-core/src/main/java/net/roboconf/core/model/RecipesValidator.java
+++ b/core/roboconf-core/src/main/java/net/roboconf/core/model/RecipesValidator.java
@@ -58,7 +58,7 @@ import net.roboconf.core.utils.Utils;
  * runtime but also in external tools.
  * </p>
  * <p>
- * This is why we allow this class to break modularity.<br />
+ * This is why we allow this class to break modularity.<br>
  * And once again, it aims at bringing useful feedback to users.
  * </p>
  *

--- a/core/roboconf-core/src/main/java/net/roboconf/core/model/helpers/ImportHelpers.java
+++ b/core/roboconf-core/src/main/java/net/roboconf/core/model/helpers/ImportHelpers.java
@@ -52,7 +52,7 @@ public final class ImportHelpers {
 	/**
 	 * Determines whether an instance has all the imports it needs.
 	 * <p>
-	 * Master of Obvious said:<br />
+	 * Master of Obvious said:<br>
 	 * By definition, optional imports are not considered to be required.
 	 * </p>
 	 *

--- a/core/roboconf-core/src/main/java/net/roboconf/core/model/helpers/InstanceHelpers.java
+++ b/core/roboconf-core/src/main/java/net/roboconf/core/model/helpers/InstanceHelpers.java
@@ -96,9 +96,9 @@ public final class InstanceHelpers {
 	/**
 	 * Builds a list of instances ordered hierarchically.
 	 * <p>
-	 * Basically, we give it a root instance (level 0).<br />
-	 * This instance is added in the list head.<br />
-	 * Then, it adds child instances at level 1.<br />
+	 * Basically, we give it a root instance (level 0).<br>
+	 * This instance is added in the list head.<br>
+	 * Then, it adds child instances at level 1.<br>
 	 * Then, at level 2, etc.
 	 * </p>
 	 * <p>
@@ -331,9 +331,9 @@ public final class InstanceHelpers {
 	 * @param application an application (not null)
 	 * @return a non-null list of instances
 	 * <p>
-	 * The result is a list made up of ordered lists.<br />
-	 * root-0, child-0-1, child-0-2, child-0-1-1, etc.<br />
-	 * root-1, child-1-1, child-1-2, child-1-1-1, etc.<br />
+	 * The result is a list made up of ordered lists.<br>
+	 * root-0, child-0-1, child-0-2, child-0-1-1, etc.<br>
+	 * root-1, child-1-1, child-1-2, child-1-1-1, etc.<br>
 	 * </p>
 	 * <p>
 	 * It means the resulting list can be considered as valid for starting instances
@@ -357,7 +357,7 @@ public final class InstanceHelpers {
 	 * 		<li>Check that the graph(s) allow it (coherence with respect to the components).</li>
 	 * 		<li>Insert the instance.</li>
 	 * 		<li>Validate the application after insertion.</li>
-	 * 		<li>Critical error => revert the insertion.</li>
+	 * 		<li>Critical error =&gt; revert the insertion.</li>
 	 * </ol>
 	 * <p>
 	 * This method assumes the application is already valid before the insertion.

--- a/core/roboconf-core/src/main/java/net/roboconf/core/utils/IconUtils.java
+++ b/core/roboconf-core/src/main/java/net/roboconf/core/utils/IconUtils.java
@@ -63,7 +63,7 @@ public final class IconUtils {
 	/**
 	 * <i>Encodes</i> the URL for an application or a template.
 	 * <p>
-	 * For an application, it looks like <code>/app/icon.jpg</code>.<br />
+	 * For an application, it looks like <code>/app/icon.jpg</code>.<br>
 	 * For a template, it looks like <code>/app/qualifier/icon.jpg</code>.
 	 * </p>
 	 * <p>

--- a/core/roboconf-core/src/main/java/net/roboconf/core/utils/UriUtils.java
+++ b/core/roboconf-core/src/main/java/net/roboconf/core/utils/UriUtils.java
@@ -107,7 +107,7 @@ public final class UriUtils {
 	 * with respect to the URI.
 	 * </p>
 	 * <p>
-	 * If the suffix is already an URL, its is returned.<br />
+	 * If the suffix is already an URL, its is returned.<br>
 	 * If the suffix is a relative file path and cannot be resolved, an exception is thrown.
 	 * </p>
 	 * <p>

--- a/core/roboconf-core/src/main/java/net/roboconf/core/utils/Utils.java
+++ b/core/roboconf-core/src/main/java/net/roboconf/core/utils/Utils.java
@@ -213,7 +213,7 @@ public final class Utils {
 	/**
 	 * Copies the content from in into os.
 	 * <p>
-	 * Neither <i>in</i> nor <i>os</i> are closed by this method.<br />
+	 * Neither <i>in</i> nor <i>os</i> are closed by this method.<br>
 	 * They must be explicitly closed after this method is called.
 	 * </p>
 	 *
@@ -234,7 +234,7 @@ public final class Utils {
 	/**
 	 * Copies the content from in into outputFile.
 	 * <p>
-	 * <i>in</i> is not closed by this method.<br />
+	 * <i>in</i> is not closed by this method.<br>
 	 * It must be explicitly closed after this method is called.
 	 * </p>
 	 *
@@ -651,7 +651,7 @@ public final class Utils {
 	/**
 	 * Writes an exception's stack trace into a string.
 	 * <p>
-	 * This method used to be public.<br />
+	 * This method used to be public.<br>
 	 * Its visibility was reduced to promote {@link #logException(Logger, Exception)},
 	 * which has better performances.
 	 * </p>

--- a/core/roboconf-dm-rest-services/src/main/java/net/roboconf/dm/rest/services/internal/cors/ResponseCorsFilter.java
+++ b/core/roboconf-dm-rest-services/src/main/java/net/roboconf/dm/rest/services/internal/cors/ResponseCorsFilter.java
@@ -37,7 +37,7 @@ import com.sun.jersey.spi.container.ContainerResponseFilter;
 /**
  * A filter to handle CORS.
  * <p>
- * CORS means Cross-Origin Domain.<br />
+ * CORS means Cross-Origin Domain.<br>
  * We use this filter to allow our REST clients to be served from
  * a different domain than our REST API.
  * </p>

--- a/core/roboconf-dm-rest-services/src/main/java/net/roboconf/dm/rest/services/internal/resources/IDebugResource.java
+++ b/core/roboconf-dm-rest-services/src/main/java/net/roboconf/dm/rest/services/internal/resources/IDebugResource.java
@@ -93,7 +93,6 @@ public interface IDebugResource {
 	 * </ul>
 	 * </li>
 	 * </ol>
-	 * </p>
 	 *
 	 * @param message a customized message content.
 	 * @param timeout the timeout in milliseconds (ms) to wait before considering the message is lost.
@@ -123,7 +122,6 @@ public interface IDebugResource {
 	 * </ul>
 	 * </li>
 	 * </ol>
-	 * </p>
 	 *
 	 * @param applicationName  the name of the application holding the targeted agent.
 	 * @param rootInstanceName the identifier of the targeted agent.

--- a/core/roboconf-dm-rest-services/src/main/java/net/roboconf/dm/rest/services/internal/resources/IManagementResource.java
+++ b/core/roboconf-dm-rest-services/src/main/java/net/roboconf/dm/rest/services/internal/resources/IManagementResource.java
@@ -86,7 +86,7 @@ public interface IManagementResource {
 	 * equivalent solution) to upload a file on the DM's machine.
 	 * </p>
 	 * <p>
-	 * This operation covers this use case.<br />
+	 * This operation covers this use case.<br>
 	 * It will load an application from a file which was already uploaded
 	 * on the DM's machine.
 	 * </p>

--- a/core/roboconf-dm-templating/src/main/java/net/roboconf/dm/templating/internal/TemplateWatcher.java
+++ b/core/roboconf-dm-templating/src/main/java/net/roboconf/dm/templating/internal/TemplateWatcher.java
@@ -90,7 +90,7 @@ public class TemplateWatcher extends FileAlterationListenerAdaptor {
 	 * The templates being watched, index by the name of the scoped application (or {@code null} for global templates)
 	 * and then by the template identifier.
 	 *
-	 * @GuardedBy lock
+	 * GuardedBy lock
 	 */
 	private final Map<String, Map<String, TemplateEntry>> templates = new HashMap<String, Map<String, TemplateEntry>>();
 
@@ -178,7 +178,7 @@ public class TemplateWatcher extends FileAlterationListenerAdaptor {
 	/**
 	 * Start this template watcher.
 	 *
-	 * @GuardedBy this.manager.globalLock.writeLock()
+	 * GuardedBy this.manager.globalLock.writeLock()
 	 */
 	public void start() {
 		try {
@@ -192,7 +192,7 @@ public class TemplateWatcher extends FileAlterationListenerAdaptor {
 	/**
 	 * Stop this template watcher.
 	 *
-	 * @GuardedBy this.manager.globalLock.writeLock()
+	 * GuardedBy this.manager.globalLock.writeLock()
 	 */
 	public void stop() {
 		try {
@@ -272,7 +272,7 @@ public class TemplateWatcher extends FileAlterationListenerAdaptor {
 	 * Add/update the given template entry in the {@code templates} map.
 	 *
 	 * @param templateEntry the template entry to add/update.
-	 * @GuardedBy this.lock.writeLock()
+	 * GuardedBy this.lock.writeLock()
 	 */
 	private void updateTemplateEntry( final TemplateEntry templateEntry ) {
 		Map<String, TemplateEntry> specificTemplates = this.templates.get(templateEntry.appName);

--- a/core/roboconf-dm-templating/src/main/java/net/roboconf/dm/templating/internal/TemplatingManager.java
+++ b/core/roboconf-dm-templating/src/main/java/net/roboconf/dm/templating/internal/TemplatingManager.java
@@ -77,7 +77,7 @@ public class TemplatingManager implements TemplatingManagerService, TemplatingSe
 
 	/**
 	 * The Roboconf configuration directory.
-	 * @GuardedBy this.lock
+	 * GuardedBy this.lock
 	 * @see #startTemplating(File)
 	 */
 	private File configDir;
@@ -85,7 +85,7 @@ public class TemplatingManager implements TemplatingManagerService, TemplatingSe
 	/**
 	 * The templates directory: {@code ${configDir}}/{@value #TEMPLATE_DIRECTORY}.
 	 *
-	 * @GuardedBy this.lock
+	 * GuardedBy this.lock
 	 * @see #resetTemplateWatcher()
 	 */
 	private File templateDir;
@@ -93,7 +93,7 @@ public class TemplatingManager implements TemplatingManagerService, TemplatingSe
 	/**
 	 * The target directory: {@code ${configDir}}/{@value #TARGET_DIRECTORY}.
 	 *
-	 * @GuardedBy this.lock
+	 * GuardedBy this.lock
 	 * @see #resetTemplateWatcher()
 	 */
 	private File targetDir;
@@ -101,7 +101,7 @@ public class TemplatingManager implements TemplatingManagerService, TemplatingSe
 	/**
 	 * The poll interval for the template watcher, or any negative value to disable.
 	 *
-	 * @GuardedBy this.lock
+	 * GuardedBy this.lock
 	 * @see #setPollInterval(long)
 	 */
 	private long pollInterval;
@@ -109,7 +109,7 @@ public class TemplatingManager implements TemplatingManagerService, TemplatingSe
 	/**
 	 * The monitored applications, indexed by name.
 	 *
-	 * @GuardedBy this.lock
+	 * GuardedBy this.lock
 	 * @see #addApplication(Application)
 	 * @see #removeApplication(Application)
 	 * @see #stopTemplating()
@@ -118,7 +118,7 @@ public class TemplatingManager implements TemplatingManagerService, TemplatingSe
 
 	/**
 	 * The template watcher.
-	 * @GuardedBy this.lock
+	 * GuardedBy this.lock
 	 */
 	private TemplateWatcher templateWatcher;
 
@@ -190,7 +190,7 @@ public class TemplatingManager implements TemplatingManagerService, TemplatingSe
 
 	/**
 	 * Updates the template watcher after a change in the templating manager configuration.
-	 * @GuardedBy this.lock.writeLock()
+	 * GuardedBy this.lock.writeLock()
 	 */
 	private void resetTemplateWatcher() {
 		// The template & poll interval may have changed. The template watcher must be updated because it is tracking
@@ -294,7 +294,7 @@ public class TemplatingManager implements TemplatingManagerService, TemplatingSe
 	 * Does nothing if templating is started, fail otherwise.
 	 *
 	 * @throws IllegalStateException if templating is not started.
-	 * @GuardedBy this.lock
+	 * GuardedBy this.lock
 	 */
 	private void ensureTemplatingIsStarted() {
 		if (this.configDir == null) {

--- a/core/roboconf-dm/src/main/java/net/roboconf/dm/internal/autonomic/RuleBasedEventHandler.java
+++ b/core/roboconf-dm/src/main/java/net/roboconf/dm/internal/autonomic/RuleBasedEventHandler.java
@@ -85,7 +85,6 @@ public class RuleBasedEventHandler {
 	/**
 	 * Reacts upon autonomic monitoring message (aka "autonomic event").
 	 * @param event The autonomic event message
-	 * @throws Exception
 	 */
 	public void handleEvent( ManagedApplication ma, MsgNotifAutonomic event ) {
 

--- a/core/roboconf-dm/src/main/java/net/roboconf/dm/internal/utils/ConfigurationUtils.java
+++ b/core/roboconf-dm/src/main/java/net/roboconf/dm/internal/utils/ConfigurationUtils.java
@@ -90,7 +90,6 @@ public final class ConfigurationUtils {
 	 * Saves the instances into a file.
 	 * @param ma the application (not null)
 	 * @param configurationDirectory the configuration directory
-	 * @throws IOException if something went wrong
 	 */
 	public static void saveInstances( ManagedApplication ma, File configurationDirectory ) {
 

--- a/core/roboconf-dm/src/main/java/net/roboconf/dm/management/Manager.java
+++ b/core/roboconf-dm/src/main/java/net/roboconf/dm/management/Manager.java
@@ -81,10 +81,10 @@ import net.roboconf.target.api.TargetHandler;
  * of instances. Therefore, the DM does the minimal set of actions on instances.
  * </p>
  * <p>
- * This class is designed to work with OSGi, iPojo and Admin Config.<br />
+ * This class is designed to work with OSGi, iPojo and Admin Config.<br>
  * But it can also be used programmatically.
  * </p>
- * <code><pre>
+ * <pre><code>
  * // Configure
  * Manager manager = new Manager();
  * manager.setMessagingType( "rabbitmq" );
@@ -94,7 +94,7 @@ import net.roboconf.target.api.TargetHandler;
  *
  * // Connect to the messaging server
  * manager.start();
- * </pre></code>
+ * </code></pre>
  *
  * @author Noël - LIG
  * @author Pierre-Yves Gibello - Linagora

--- a/core/roboconf-messaging-api/src/main/java/net/roboconf/messaging/api/processors/AbstractMessageProcessor.java
+++ b/core/roboconf-messaging-api/src/main/java/net/roboconf/messaging/api/processors/AbstractMessageProcessor.java
@@ -36,7 +36,7 @@ import net.roboconf.messaging.api.reconfigurables.ReconfigurableClient;
 /**
  * A message processor is in charge of (guess what) processing messages.
  * <p>
- * The DM is supposed to have only one message processor running.<br />
+ * The DM is supposed to have only one message processor running.<br>
  * Same thing for an agent. When the DM or an agent stops, the processor thread should be stopped.
  * </p>
  * <p>

--- a/core/roboconf-plugin-puppet/src/main/java/net/roboconf/plugin/puppet/internal/PluginPuppet.java
+++ b/core/roboconf-plugin-puppet/src/main/java/net/roboconf/plugin/puppet/internal/PluginPuppet.java
@@ -67,7 +67,7 @@ import net.roboconf.plugin.api.PluginInterface;
  * have the running state to RUNNING or to STOPPED.
  * </p>
  * <p>
- * The action is one of "deploy", "start", "stop", "undeploy" and "update".<br />
+ * The action is one of "deploy", "start", "stop", "undeploy" and "update".<br>
  * Let's take an example with the "start" action to understand the way this plug-in works.
  * </p>
  * <ul>
@@ -403,7 +403,7 @@ public class PluginPuppet implements PluginInterface {
 	/**
 	 * Returns a String representing all the exported variables and their value.
 	 * <p>
-	 * Must be that way:<br />
+	 * Must be that way:<br>
 	 * {@code varName1 => 'varValue1', varName2 => undef, varName3 => 'varValue3'}
 	 * </p>
 	 * <p>
@@ -411,8 +411,8 @@ public class PluginPuppet implements PluginInterface {
 	 * is not required.
 	 * </p>
 	 * <p>
-	 * As an example...<br />
-	 * Export "Redis.port = 4040" will generate "port => 4040".<br />
+	 * As an example...<br>
+	 * Export "Redis.port = 4040" will generate "port => 4040".<br>
 	 * Export "Redis.port = null" will generate "port => undef".
 	 * </p>
 	 *

--- a/core/roboconf-plugin-script/src/main/java/net/roboconf/plugin/script/internal/PluginScript.java
+++ b/core/roboconf-plugin-script/src/main/java/net/roboconf/plugin/script/internal/PluginScript.java
@@ -48,7 +48,7 @@ import net.roboconf.plugin.api.template.InstanceTemplateHelper;
 /**
  * The plug-in invokes a script (eg. shell) on every life cycle change.
  * <p>
- * The action is one of "deploy", "start", "stop", "undeploy" and "update".<br />
+ * The action is one of "deploy", "start", "stop", "undeploy" and "update".<br>
  * Let's take an example with the "start" action to understand the way this plug-in works.
  * </p>
  * <ul>

--- a/core/roboconf-target-api/src/main/java/net/roboconf/target/api/AbstractThreadedTargetHandler.java
+++ b/core/roboconf-target-api/src/main/java/net/roboconf/target/api/AbstractThreadedTargetHandler.java
@@ -45,7 +45,7 @@ import net.roboconf.core.utils.Utils;
  * Rather than blocking a thread, this class provides a timer to schedule configuration steps.
  * </p>
  * <p>
- * To use this class, just extend it and implement {@link MachineConfigurator}.<br />
+ * To use this class, just extend it and implement {@link MachineConfigurator}.<br>
  * A machine configurator is in charge of configuring a machine. There will be one instance per
  * VM instance. This instance will be invoked periodically until the machine configuration is completed.
  * </p>

--- a/core/roboconf-target-api/src/main/java/net/roboconf/target/api/TargetHandler.java
+++ b/core/roboconf-target-api/src/main/java/net/roboconf/target/api/TargetHandler.java
@@ -44,7 +44,7 @@ public interface TargetHandler {
 	/**
 	 * Creates a machine.
 	 * <p>
-	 * The machine must have a Roboconf agent installed on it.<br />
+	 * The machine must have a Roboconf agent installed on it.<br>
 	 * This method only deals with the creation of a VM. Configuring the network,
 	 * storage and so on, should be done {@link #configureMachine(Map, Map, String, String, String, Instance)}.
 	 * </p>

--- a/core/roboconf-target-docker/src/main/java/net/roboconf/target/docker/internal/DockerfileGenerator.java
+++ b/core/roboconf-target-docker/src/main/java/net/roboconf/target/docker/internal/DockerfileGenerator.java
@@ -62,7 +62,7 @@ public class DockerfileGenerator {
 	 *
 	 * @param baseImageName the name of the base image used to create a new image
 	 * <p>
-	 * This parameter can be null.<br />
+	 * This parameter can be null.<br>
 	 * In this case, "ubuntu" will be used as the
 	 * base image name (<code>FROM ubuntu</code>).
 	 * </p>

--- a/miscellaneous/roboconf-dm-rest-client/src/main/java/net/roboconf/dm/rest/client/WsClient.java
+++ b/miscellaneous/roboconf-dm-rest-client/src/main/java/net/roboconf/dm/rest/client/WsClient.java
@@ -57,7 +57,7 @@ import com.sun.jersey.api.client.config.DefaultClientConfig;
  * Thrown exceptions contain the error code and the error message.
  * </p>
  * <p>
- * About the logging policy...<br />
+ * About the logging policy...<br>
  * Every client method logs an entry when it is invoked.
  * It logs a second entry once the REST invocation has completed, and provided a runtime
  * exception was not thrown by the REST library.

--- a/miscellaneous/roboconf-integration-tests/src/test/java/net/roboconf/integration/tests/DelayedAgentInitializationTest.java
+++ b/miscellaneous/roboconf-integration-tests/src/test/java/net/roboconf/integration/tests/DelayedAgentInitializationTest.java
@@ -58,7 +58,7 @@ import org.ops4j.pax.exam.spi.reactors.PerMethod;
 /**
  * Checks delayed initialization.
  * <p>
- * Configure an agent correctly and the DM incorrectly.<br />
+ * Configure an agent correctly and the DM incorrectly.<br>
  * Wait a little bit and reconfigure the DM with the right messaging
  * credentials. Make sure the agent's model is initialized correctly.
  * </p>


### PR DESCRIPTION
Error detection using Java 8's "-Xdoclint:reference,html,syntax"
A maven profile with this configuration should be added to CI builds promptly.
Tons of warnings are still remaining.